### PR TITLE
默认文件名改为项目名称等

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+*.srt
+
 /.idea/
 /.vscode/
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,143 @@
+/.idea/
+/.vscode/
+
+# https://github.com/github/gitignore/blob/master/Python.gitignore
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # 转换剪映字幕
 
+[![GitHub stars](https://img.shields.io/github/stars/YDX-2147483647/Jianying-to-srt)](https://github.com/YDX-2147483647/Jianying-to-srt/stargazers)
+
 > 2021年4月30日。
 
 [剪映](https://lv.ulikecam.com/)是一款剪辑软件，据说它的（中文）字幕识别效果特别好，然而无法导出导出字幕文件。还好其轨道是用 JSON 存储的，可由此制作 *.srt 字幕文件。

--- a/draft_content.py
+++ b/draft_content.py
@@ -26,12 +26,14 @@ def draft_content_to_tracks(draft_content: json) -> list:
 
 
 def get_material_name(draft_content: json) -> str:
+    """获取视频轨第一个视频的名字
+    注意，若无视频，会炸。
+    """
     return draft_content['materials']['videos'][0]['material_name']
 
 
-def read_draft_content_src(directory: str) -> (list, str):
+def read_draft_content_src(directory: str) -> list:
     with open(directory, 'r', encoding='utf-8') as f:
         draft_content = json.loads(f.read())
     tracks = draft_content_to_tracks(draft_content)
-    name = get_material_name(draft_content)
-    return tracks, name
+    return tracks

--- a/draft_content.py
+++ b/draft_content.py
@@ -24,8 +24,10 @@ def draft_content_to_tracks(draft_content):
 
     return tracks
 
+
 def get_material_name(draft_content):
     return draft_content['materials']['videos'][0]['material_name']
+
 
 def read_draft_content_src(directory):
     with open(directory, 'r', encoding='utf-8') as f:

--- a/draft_content.py
+++ b/draft_content.py
@@ -1,7 +1,7 @@
 import json
 
 
-def draft_content_to_tracks(draft_content):
+def draft_content_to_tracks(draft_content: json) -> list:
     texts = {t['id']: t['content']
              for t in draft_content['materials']['texts']
              if t['type'] == 'subtitle'}
@@ -25,11 +25,11 @@ def draft_content_to_tracks(draft_content):
     return tracks
 
 
-def get_material_name(draft_content):
+def get_material_name(draft_content: json) -> str:
     return draft_content['materials']['videos'][0]['material_name']
 
 
-def read_draft_content_src(directory):
+def read_draft_content_src(directory: str) -> (list, str):
     with open(directory, 'r', encoding='utf-8') as f:
         draft_content = json.loads(f.read())
     tracks = draft_content_to_tracks(draft_content)

--- a/draft_meta_info.py
+++ b/draft_meta_info.py
@@ -1,0 +1,26 @@
+import json
+from os.path import join, dirname
+
+
+def get_meta_info_path(content_path: str) -> str:
+    """
+    获取 meta_info.json 的路径
+    :param content_path: content.json 的路径
+    :return: draft_meta_info.json 的路径
+    """
+    return join(dirname(content_path), 'draft_meta_info.json')
+
+
+def get_draft_name(directory: str) -> str:
+    """
+    获取项目名称
+    :param directory: meta_info.json 的路径
+    :return: 项目名称
+    """
+    with open(directory, 'r', encoding='utf-8') as f:
+        meta_info = json.loads(f.read())
+    return meta_info['draft_name']
+
+
+def get_draft_name_from_content_path(content_path: str) -> str:
+    return get_draft_name(get_meta_info_path(content_path))

--- a/main.py
+++ b/main.py
@@ -1,13 +1,13 @@
-import os
-import glob
+from os import getenv
 from os.path import join, getctime
+import glob
 
 from draft_content import read_draft_content_src
 from simple_srt import tracks_to_srt_string
 from draft_meta_info import get_draft_name_from_content_path
 
 if __name__ == '__main__':
-    drafts_parent = join(os.getenv("LOCALAPPDATA"), './JianyingPro/User Data/Projects/com.lveditor.draft/')
+    drafts_parent = join(getenv("LOCALAPPDATA"), './JianyingPro/User Data/Projects/com.lveditor.draft/')
     drafts_contents = glob.glob(drafts_parent + './*/draft_content.json')
     latest_draft_content = max(drafts_contents, key=getctime)
     print('最新创建的剪映草稿文件如下。')

--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ if __name__ == '__main__':
     if not draft_content:
         draft_content = latest_draft_content
 
-    tracks, _ = read_draft_content_src(draft_content)
+    tracks = read_draft_content_src(draft_content)
     name = get_draft_name_from_content_path(draft_content)
 
     subtitle_filename = f'./{name}.srt'

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ from os.path import join, getctime
 
 from draft_content import read_draft_content_src
 from simple_srt import tracks_to_srt_string
+from draft_meta_info import get_draft_name_from_content_path
 
 if __name__ == '__main__':
     drafts_parent = join(os.getenv("LOCALAPPDATA"), './JianyingPro/User Data/Projects/com.lveditor.draft/')
@@ -16,9 +17,10 @@ if __name__ == '__main__':
     if not draft_content:
         draft_content = latest_draft_content
 
-    tracks, name = read_draft_content_src(draft_content)
+    tracks, _ = read_draft_content_src(draft_content)
+    name = get_draft_name_from_content_path(draft_content)
 
-    subtitle_filename = './' + os.path.splitext(name)[0] + '.srt'
+    subtitle_filename = f'./{name}.srt'
     with open(subtitle_filename, 'w', encoding='utf-8') as f:
         f.write(tracks_to_srt_string(tracks))
 

--- a/main.py
+++ b/main.py
@@ -1,20 +1,26 @@
+import os
+import glob
+from os.path import join, getctime
+
 from draft_content import read_draft_content_src
 from simple_srt import tracks_to_srt_string
-import os
 
 if __name__ == '__main__':
-    draft = os.getenv("LOCALAPPDATA") + '\\JianyingPro\\User Data\\Projects\\com.lveditor.draft\\'
-    draft_content_directory_default = draft + os.listdir(draft)[-2]+'\\draft_content.json'
-    print('最新创建的剪映草稿文件是'+ draft_content_directory_default)
+    drafts_parent = join(os.getenv("LOCALAPPDATA"), './JianyingPro/User Data/Projects/com.lveditor.draft/')
+    drafts_contents = glob.glob(drafts_parent + './*/draft_content.json')
+    latest_draft_content = max(drafts_contents, key=getctime)
+    print('最新创建的剪映草稿文件如下。')
+    print(latest_draft_content)
 
-    draft_content_directory = input("请输入 draft_content.json 的地址，或回车使用上面的文件")
-    if not draft_content_directory:
-        draft_content_directory = draft_content_directory_default
-        
-    tracks, name = read_draft_content_src(draft_content_directory)
+    draft_content = input("请输入 draft_content.json 的地址，留空则使用上面的文件。>>>")
+    if not draft_content:
+        draft_content = latest_draft_content
 
-    srtname = './' + os.path.splitext(name)[0] + '.srt'
-    with open(srtname, 'w', encoding='utf-8') as f:
+    tracks, name = read_draft_content_src(draft_content)
+
+    subtitle_filename = './' + os.path.splitext(name)[0] + '.srt'
+    with open(subtitle_filename, 'w', encoding='utf-8') as f:
         f.write(tracks_to_srt_string(tracks))
-    
-    input('请查收 ' + srtname)
+
+    print(f'请查收 {subtitle_filename}。')
+    input('请按 Enter 继续. . .')


### PR DESCRIPTION
具体更改：
- 从 [github/gitignore](https://github.com/github/) 添加了 [Python.gitignore](https://github.com/github/gitignore/blob/master/Python.gitignore)。
- 你原来获取最新的项目是用`os.listdir(…)[-2]`（-1 是`root_draft_meta_info.json`，不对应项目，需要跳过），这要求`os.listdir()`按日期升序排列；然而[文档](https://docs.python.org/zh-cn/3.9/library/os.html?highlight=%E6%8C%89%E4%BB%BB%E6%84%8F%E9%A1%BA%E5%BA%8F%E6%8E%92%E5%88%97#os.listdir)特别说“按任意顺序排列”，故可能导致意外。我改成用`max()`来找最新的了。
- 字幕文件原来的文件名好像（我没仔细查）来自项目中视频的文件名，这不太友好，因为那可能是`VID_○○○○_○○.mp4`。因此我改成项目名称了，它存储在同目录的`draft_meta_info.json`。

// 第一次被 fork，谢谢！